### PR TITLE
Fix user check in pagination helper

### DIFF
--- a/cogs/Global_Cogs/MiscCMD.py
+++ b/cogs/Global_Cogs/MiscCMD.py
@@ -182,8 +182,15 @@ class MiscCMD(commands.Cog):
             db = Path("data.db")
             if db.exists():
                 db.unlink()
+
+            if not ctx.message.attachments:
+                await ctx.send("No attachment found to replace database.")
+                return
+
+            attachment = ctx.message.attachments[0]
             with db.open(mode="wb+") as f:
-                await ctx.message.attachments.save(f)
+                await attachment.save(f)
+            await ctx.send("Database file replaced.")
         else:
             await ctx.send("Cannot replace; database is currently in use.")
 

--- a/core/common.py
+++ b/core/common.py
@@ -41,7 +41,11 @@ async def paginate_embed(bot: discord.Client,
     emotes = ["◀️", "▶️"]
 
     async def check_reaction(reaction, user):
-        return await user == ctx.author and str(reaction.emoji) in emotes
+        # `user` is not awaitable. Attempting to await it will raise a
+        # ``TypeError``. The intention here is to simply check that the
+        # reaction author matches the command author and that the emoji is one
+        # of the expected navigation emotes.
+        return user == ctx.author and str(reaction.emoji) in emotes
 
     embed = await population_func(embed, page)
     if isinstance(embed, discord.Embed):


### PR DESCRIPTION
## Summary
- fix reaction user check in `paginate_embed` helper
- correct attachment handling in `replacedb` command

## Testing
- `python -m py_compile cogs/Global_Cogs/MiscCMD.py`
- `find . -name '*.py' | xargs python -m py_compile`


------
https://chatgpt.com/codex/tasks/task_e_6858423ed55883238e8bcff534463a16