### PR TITLE
Switch asset paths from ./core/images to ./data/images for profiles and realms

### DIFF
--- a/data/misc_code/profiles
+++ b/data/misc_code/profiles
@@ -132,15 +132,15 @@ class ProfileCMD(commands.Cog):
     RADIUS = 15  # Rounded corners radius for the progress bar
     FONT_PATH = "./core/fonts/Minecraft-Seven_v2-1.ttf"
     EMOJI_FONT_PATH = "./core/fonts/NotoColorEmoji-Regular.ttf"
-    BACKGROUND_IMAGE_PATH = "./core/images/profilebackground4.png"
+    BACKGROUND_IMAGE_PATH = "./data/images/profilebackground4.png"
     TEXT_COLOR = (255, 255, 255, 255)
     SHADOW_COLOR = (0, 0, 0, 200)  # Black with transparency
     SHADOW_OFFSET = 2  # Shadow offset for text
 
     # Paths for console logo images
-    PS_LOGO_PATH = "./core/images/ps-logo.png"
-    XBOX_LOGO_PATH = "./core/images/xbox-logo.png"
-    NS_LOGO_PATH = "./core/images/ns-logo.png"
+    PS_LOGO_PATH = "./data/images/ps-logo.png"
+    XBOX_LOGO_PATH = "./data/images/xbox-logo.png"
+    NS_LOGO_PATH = "./data/images/ns-logo.png"
 
     @PF.command(name="profile", description="Generates a profile card.")
     async def profile(

--- a/data/misc_code/profiles copy
+++ b/data/misc_code/profiles copy
@@ -20,7 +20,7 @@ class ProfileCMD(commands.Cog):
     BAR_HEIGHT = 30  # Progress bar height
     RADIUS = 15  # Rounded corners radius for the progress bar
     FONT_PATH = "./core/fonts/Minecraft-Seven_v2-1.ttf"
-    BACKGROUND_IMAGE_PATH = './core/images/profilebackground4.png'
+    BACKGROUND_IMAGE_PATH = './data/images/profilebackground4.png'
     TEXT_COLOR = (255, 255, 255, 255)
     SHADOW_COLOR = (0, 0, 0, 200)  # Black with transparency
     SHADOW_OFFSET = 2  # Shadow offset for text

--- a/data/misc_code/realm_profiles
+++ b/data/misc_code/realm_profiles
@@ -19,9 +19,9 @@ class RealmProfiles(commands.Cog):
         self.bot = bot
 
     # Constants
-    BACKGROUND_IMAGE_PATH = "./core/images/realm_background4.png"  # Path to the Nether Portal background image
+    BACKGROUND_IMAGE_PATH = "./data/images/realm_background4.png"  # Path to the Nether Portal background image
     FONT_PATH = "./core/fonts/Minecraft-Seven_v2-1.ttf"  # Example font path
-    BANNER_IMAGE_PATH = "./core/images/realm_backround_banner.png"
+    BANNER_IMAGE_PATH = "./data/images/realm_backround_banner.png"
     AVATAR_SIZE = 100
     PADDING = 20
     TEXT_COLOR = (255, 255, 255, 255)
@@ -343,9 +343,9 @@ class RealmProfiles(commands.Cog):
                 return
 
             # Ensure directory exists
-            os.makedirs("./core/images/realms/logos/", exist_ok=True)
+            os.makedirs("./data/images/realms/logos/", exist_ok=True)
 
-            file_path = f"./core/images/realms/logos/{realm_name}_logo.png"
+            file_path = f"./data/images/realms/logos/{realm_name}_logo.png"
             await attachment.save(file_path)
 
             # Update the realm profile with the new logo path
@@ -387,9 +387,9 @@ class RealmProfiles(commands.Cog):
                 return
 
             # Ensure directory exists
-            os.makedirs("./core/images/realms/banners/", exist_ok=True)
+            os.makedirs("./data/images/realms/banners/", exist_ok=True)
 
-            file_path = f"./core/images/realms/banners/{realm_name}_banner.png"
+            file_path = f"./data/images/realms/banners/{realm_name}_banner.png"
             await attachment.save(file_path)
 
             # Update the realm profile with the new banner path

--- a/utils/realm_profiles/__rp_logic.py
+++ b/utils/realm_profiles/__rp_logic.py
@@ -105,8 +105,8 @@ async def update_realm_logo_attachment(
             )
             return
 
-        os.makedirs("./core/images/realms/logos/", exist_ok=True)
-        path = f"./core/images/realms/logos/{realm_name}_logo.png"
+        os.makedirs("./data/images/realms/logos/", exist_ok=True)
+        path = f"./data/images/realms/logos/{realm_name}_logo.png"
         await attachment.save(path)
 
         profile = RealmProfile.get_or_none(RealmProfile.realm_name == realm_name)
@@ -137,8 +137,8 @@ async def update_realm_banner_attachment(
             )
             return
 
-        os.makedirs("./core/images/realms/banners/", exist_ok=True)
-        path = f"./core/images/realms/banners/{realm_name}_banner.png"
+        os.makedirs("./data/images/realms/banners/", exist_ok=True)
+        path = f"./data/images/realms/banners/{realm_name}_banner.png"
         await attachment.save(path)
 
         profile = RealmProfile.get_or_none(RealmProfile.realm_name == realm_name)
@@ -169,8 +169,8 @@ def ensure_realm_profile_exists(realm_name: str) -> RealmProfile:
             "world_age": "Unknown",
             "play_style": "Unknown",
             "gamemode": "Survival",
-            "logo_url": "./core/images/default_logo.png",
-            "banner_url": "./core/images/default_banner.png",
+            "logo_url": "./data/images/default_logo.png",
+            "banner_url": "./data/images/default_banner.png",
         },
     )
     return profile


### PR DESCRIPTION
### Motivation
- Standardize and relocate image assets to the `./data/images` tree so profile and realm image handling uses a consistent, data-centric directory.

### Description
- Updated background, logo and console image constants to point to `./data/images/*` instead of `./core/images/*` in profile and realm-related modules.
- Updated upload/save code to create and write realm logo and banner files under `./data/images/realms/logos/` and `./data/images/realms/banners/`.
- Updated default `logo_url` and `banner_url` values in realm profile creation to reference `./data/images` defaults.
- Applied the same path changes in the realm profile logic helper functions to ensure saved files and generated cards reference the new locations.

### Testing
- Ran the project's test suite with `pytest -q`, and all tests completed successfully.
- Ran static checks/linting (e.g. `flake8`) to validate imports and path updates, and no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a388e1232208323ab43f3464b18cf6d)